### PR TITLE
修复mhy更改api造成的应用错误

### DIFF
--- a/ys_UserInfoGet.py
+++ b/ys_UserInfoGet.py
@@ -13,13 +13,13 @@ from ys_api.cookie_set import timestamp_to_text
 {body:"",query:{"action_ticket": undefined, "game_biz": "hk4e_cn”}}
 对应 https://api-takumi.mihoyo.com/binding/api/getUserGameRolesByCookie?game_biz=hk4e_cn //查询米哈游账号下绑定的游戏(game_biz可留空)
 {body:"",query:{"uid": 12345(被查询账号米哈游uid)}}
-对应 https://api-takumi.mihoyo.com/game_record/app/card/wapi/getGameRecordCard?uid=
+对应 https://api-takumi-record.mihoyo.com/game_record/app/card/wapi/getGameRecordCard?uid=
 {body:"",query:{'role_id': '查询账号的uid(游戏里的)' ,'server': '游戏服务器'}}
-对应 https://api-takumi.mihoyo.com/game_record/app/genshin/api/index?server= server信息 &role_id= 游戏uid
+对应 https://api-takumi-record.mihoyo.com/game_record/app/genshin/api/index?server= server信息 &role_id= 游戏uid
 {body:"",query:{'role_id': '查询账号的uid(游戏里的)' , 'schedule_type': 1(我这边只看到出现过1和2), 'server': 'cn_gf01'}}
-对应 https://api-takumi.mihoyo.com/game_record/app/genshin/api/spiralAbyss?schedule_type=1&server= server信息 &role_id= 游戏uid
+对应 https://api-takumi-record.mihoyo.com/game_record/app/genshin/api/spiralAbyss?schedule_type=1&server= server信息 &role_id= 游戏uid
 {body:"",query:{game_id: 2(目前我知道有崩坏3是1原神是2)}}
-对应 https://api-takumi.mihoyo.com/game_record/app/card/wapi/getAnnouncement?game_id=    这个是公告api
+对应 https://api-takumi-record.mihoyo.com/game_record/app/card/wapi/getAnnouncement?game_id=    这个是公告api
 b=body q=query
 其中b只在post的时候有内容，q只在get的时候有内容
 '''

--- a/ys_api/main.py
+++ b/ys_api/main.py
@@ -74,7 +74,7 @@ def GetInfo(Uid, ServerID, cookie: str, overseas=False):
         )
     else:
         req = requests.get(
-            url=f"https://api-takumi.mihoyo.com/game_record/app/genshin/api/index?server={ServerID}&role_id={Uid}",
+            url=f"https://api-takumi-record.mihoyo.com/game_record/app/genshin/api/index?server={ServerID}&role_id={Uid}",
             headers={
                 'Accept': 'application/json, text/plain, */*',
                 'DS': DSGet(f"role_id={Uid}&server={ServerID}"),
@@ -95,7 +95,7 @@ def GetInfo(Uid, ServerID, cookie: str, overseas=False):
 def userAbyss(uid, ServerID: str, cookie: str, overseas=False, Schedule_type="1"):
     ck = cookie
     if not overseas:
-        url = f"https://api-takumi.mihoyo.com/game_record/app/genshin/api/spiralAbyss?" \
+        url = f"https://api-takumi-record.mihoyo.com/game_record/app/genshin/api/spiralAbyss?" \
               f"schedule_type={Schedule_type}&server={ServerID}&role_id={uid}"
         _ver = mhyVersion
         _ctype = client_type


### PR DESCRIPTION
如题：
相关问题：https://github.com/KimigaiiWuyi/GenshinUID/issues/60

但是目前还有新的vps被封禁问题
米游社可能已经禁止国内VPS服务商的IP  
https://github.com/Arondight/Adachi-BOT/issues/522